### PR TITLE
Add pull request template for pycraft2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!-- Provide a general summary of the changes in the pull request title. -->
+
+## Description
+<!-- Describe the pull request changes in detail. -->
+
+## Related Issues
+<!-- Provide links to any issues addressed by the change. -->
+<!-- If there is no relevant issue, consider creating one to contextualize the changes prior to creating a pull request. -->
+
+## Motivation and Context
+<!-- Include relevant motivation and context. -->
+
+## Testing
+<!-- Describe how the changes have been tested. -->
+<!-- Include details for reproducing test results. -->
+<!-- Provide context for tests added as part of the pull request. -->


### PR DESCRIPTION
This will be the last PR which has no PR template. The template itself is quite generic, but is good to have in place to keep development consistent and prevent corner cutting.